### PR TITLE
add vagrant-hostsupdater automatic host

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,5 +1,10 @@
 VAGRANTFILE_API_VERSION = "2"
 
+# If hostsupdater plugin is installed, add all server names as aliases.
+unless Vagrant.has_plugin?("vagrant-hostsupdater")
+  raise "É necessário instalar o plugin 'vagrant-hostsupdater' através do comando: vagrant plugin install vagrant-hostsupdater"
+end
+
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.box = "ubuntu/trusty64"
     config.vm.network :private_network, ip: "192.168.57.102"
@@ -12,6 +17,28 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.provider :virtualbox do |v|
         v.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
         v.customize ["modifyvm", :id, "--memory", 512]	
+    end
+
+    #=========================================================================
+    #=========================================================================
+    #=========== Obrigatorio ======>  sudo visudo <===========================
+    #=========================================================================
+    #=========================================================================
+    # Allow passwordless startup of Vagrant with vagrant-hostsupdater.
+    #Cmnd_Alias VAGRANT_HOSTS_ADD = /bin/sh -c echo "*" >> /etc/hosts
+    #Cmnd_Alias VAGRANT_HOSTS_REMOVE = /usr/bin/sed -i -e /*/ d /etc/hosts
+    #%admin ALL=(root) NOPASSWD: VAGRANT_HOSTS_ADD, VAGRANT_HOSTS_REMOVE
+    #=========================================================================
+    #=========================================================================
+    #=========================================================================
+    #=========================================================================
+
+
+    # If hostsupdater plugin is installed, add all server names as aliases.
+    if Vagrant.has_plugin?("vagrant-hostsupdater")
+      # Add all hosts that aren't defined as Ansible vars.
+      config.hostsupdater.aliases = []
+      config.hostsupdater.aliases.push("desenv.dev")
     end
 
     config.vm.synced_folder "projetos", "/var/www/html", id: "vagrant-root"


### PR DESCRIPTION
Almir foi adicionado uma forma automatica de configurar a vhost;
linha4: Verificar se o plugim vagrant-hostsupdater

linha22: rodar o comando obrigatorio no sudo visudo

linha41: add o alias;
